### PR TITLE
Add rmq connection: Begins to add an rmq implementation of mq 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@
 
 # Output of the go coverage tool, specifically when used with LiteIDE
 *.out
+
+go.sum

--- a/examples/rmq/rmq.go
+++ b/examples/rmq/rmq.go
@@ -1,0 +1,27 @@
+package main
+
+import (
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/zalora/go-mq/rmq"
+)
+
+func main() {
+	rmqURL := "amqp://rpmvioqv:6skaAUvjscD5wYNwYAHDJpokk3mniG7t@vulture.rmq.cloudamqp.com/rpmvioqv"
+
+	log.Println("connecting to rmq host")
+	connection, err := rmq.NewConnection(rmqURL, 5*time.Second, nil, nil, "exampleService", "1123")
+	if err != nil {
+		log.Fatal(err, "error making new rmq connection")
+	}
+
+	log.Println("opening new channel")
+	ch, err := connection.NewChannel()
+	if err != nil {
+		log.Fatal(err, "error connecting to new channel")
+	}
+
+	fmt.Println(ch)
+}

--- a/examples/rmq/rmq.go
+++ b/examples/rmq/rmq.go
@@ -24,4 +24,5 @@ func main() {
 	}
 
 	fmt.Println(ch)
+	time.Sleep(10 * time.Second)
 }

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,7 @@ module github.com/zalora/go-mq
 
 go 1.12
 
-require github.com/streadway/amqp v0.0.0-20190404075320-75d898a42a94
+require (
+	github.com/pkg/errors v0.8.1
+	github.com/streadway/amqp v0.0.0-20190404075320-75d898a42a94
+)

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,5 @@
+module github.com/zalora/go-mq
+
+go 1.12
+
+require github.com/streadway/amqp v0.0.0-20190404075320-75d898a42a94

--- a/go.mod
+++ b/go.mod
@@ -5,4 +5,5 @@ go 1.12
 require (
 	github.com/pkg/errors v0.8.1
 	github.com/streadway/amqp v0.0.0-20190404075320-75d898a42a94
+	github.com/stretchr/testify v1.3.0
 )

--- a/mq.go
+++ b/mq.go
@@ -34,3 +34,13 @@ type Publisher interface {
 	Publish(messageType string, message Message) error
 	Close() error
 }
+
+// Logger is a very basic pluggable module some rmq implementations
+// optionally accept to log certain important events. Note that this
+// should always be an optional feature.
+type Logger interface {
+	Info(args ...interface{})
+	Debug(args ...interface{})
+	Warn(args ...interface{})
+	Error(args ...interface{})
+}

--- a/rmq/connection.go
+++ b/rmq/connection.go
@@ -1,0 +1,98 @@
+package rmq
+
+import (
+	"sync/atomic"
+	"time"
+
+	"github.com/streadway/amqp"
+	"github.com/zalora/go-mq"
+)
+
+type Connection struct {
+	amqpConn          atomic.Value
+	reconnectInterval time.Duration
+	closeCh           chan struct{}
+	logger            mq.Logger
+	retryForever      bool
+}
+
+func NewConnection(url string, cfg amqp.Config, reconnectInterval time.Duration) (*Connection, error) {
+	amqpConn, err := amqp.DialConfig(url, cfg)
+	if err != nil {
+		return nil, err
+	}
+	conn := &Connection{reconnectInterval: reconnectInterval, closeCh: make(chan struct{}, 1)}
+	conn.amqpConn.Store(amqpConn)
+	go conn.handleConnectionErr(url, cfg)
+	return conn, nil
+}
+
+func (c *Connection) Close() {
+	if c.closeCh != nil {
+		close(c.closeCh)
+	}
+	return
+}
+
+func (c *Connection) RetryForever() *Connection {
+	c.retryForever = true
+	return c
+}
+
+func (c *Connection) amqpConnection() *amqp.Connection {
+	return c.amqpConn.Load().(*amqp.Connection)
+}
+
+func (c *Connection) NewChannel() (*amqp.Channel, error) {
+	ch, err := c.amqpConnection().Channel()
+	if err != nil {
+		for {
+			time.Sleep(2 * c.reconnectInterval)
+			ch, err := c.amqpConnection().Channel()
+			if err == nil {
+				return ch, nil
+			}
+			if !c.retryForever {
+				return nil, err
+			}
+		}
+	}
+	return ch, nil
+}
+
+func (c *Connection) SetLogger(logger mq.Logger) {
+	c.logger = logger
+}
+
+func (c *Connection) handleConnectionErr(url string, cfg amqp.Config) {
+	connErrCh := make(chan *amqp.Error, 1)
+	isConnAlive := true
+	c.amqpConnection().NotifyClose(connErrCh)
+	for {
+		select {
+		case <-c.closeCh:
+			if isConnAlive {
+				c.amqpConnection().Close()
+			}
+			c.closeCh = nil
+			return
+		case <-connErrCh:
+			isConnAlive = false
+			if c.logger != nil {
+				c.logger.Info("rabbitmq connection lost")
+			}
+			amqpConn, err := amqp.DialConfig(url, cfg)
+			if err != nil {
+				time.Sleep(c.reconnectInterval)
+				continue
+			}
+			isConnAlive = true
+			connErrCh = make(chan *amqp.Error, 1)
+			amqpConn.NotifyClose(connErrCh)
+			if c.logger != nil {
+				c.logger.Info("rabbitmq connection restored")
+			}
+			c.amqpConn.Store(amqpConn)
+		}
+	}
+}

--- a/rmq/connection.go
+++ b/rmq/connection.go
@@ -1,7 +1,6 @@
 package rmq
 
 import (
-	"fmt"
 	"sync"
 	"time"
 
@@ -98,7 +97,6 @@ func (c *Connection) NewChannel() (*amqp.Channel, error) {
 	c.Lock()
 	defer c.Unlock()
 	ch, err := c.amqpConn.Channel()
-	fmt.Println(ch, err)
 	if err != nil {
 		for {
 			time.Sleep(2 * c.reconnectInterval)

--- a/rmq/connection.go
+++ b/rmq/connection.go
@@ -124,7 +124,11 @@ func (c *Connection) handleConnectionErr(url string, cfg amqp.Config) {
 			}
 			c.closeCh = nil
 			return
-		case <-connErrCh:
+		case connErr := <-connErrCh:
+			// We don't want to try to recover if rmq tells us not to recover.
+			if !connErr.Recover {
+				return
+			}
 			isConnAlive = false
 			if c.logger != nil {
 				c.logger.Info("rabbitmq connection lost")

--- a/rmq/connection.go
+++ b/rmq/connection.go
@@ -89,7 +89,7 @@ func (c *Connection) NewChannel() (*amqp.Channel, error) {
 				return ch, nil
 			}
 			if !c.retryForever {
-				return nil, err
+				return nil, errors.Wrap(err, "error getting channel from amqp")
 			}
 		}
 	}

--- a/rmq/connection_test.go
+++ b/rmq/connection_test.go
@@ -1,0 +1,22 @@
+package rmq
+
+import "github.com/streadway/amqp"
+
+type fakeAmqpConn struct {
+	ch  *amqp.Channel
+	err error
+}
+
+func (f *fakeAmqpConn) Channel() (*amqp.Channel, error) {
+	return f.ch, f.err
+}
+
+func (f *fakeAmqpConn) Close() error {
+	// dont really care about this.
+	return nil
+}
+
+func (f *fakeAmqpConn) NotifyClose(receiver chan *amqp.Error) chan *amqp.Error {
+	// similar we dont use this return value for now.
+	return nil
+}

--- a/rmq/connection_test.go
+++ b/rmq/connection_test.go
@@ -1,13 +1,28 @@
 package rmq
 
-import "github.com/streadway/amqp"
+import (
+	"errors"
+	"testing"
+	"time"
+
+	pkgerrors "github.com/pkg/errors"
+	"github.com/streadway/amqp"
+	"github.com/stretchr/testify/assert"
+)
 
 type fakeAmqpConn struct {
-	ch  *amqp.Channel
-	err error
+	ch                   *amqp.Channel
+	calls                int
+	noOfCallsToReturnErr int
+	err                  error
 }
 
 func (f *fakeAmqpConn) Channel() (*amqp.Channel, error) {
+	f.calls++
+	if f.calls > f.noOfCallsToReturnErr {
+		return f.ch, nil
+	}
+
 	return f.ch, f.err
 }
 
@@ -19,4 +34,74 @@ func (f *fakeAmqpConn) Close() error {
 func (f *fakeAmqpConn) NotifyClose(receiver chan *amqp.Error) chan *amqp.Error {
 	// similar we dont use this return value for now.
 	return nil
+}
+
+type fakeDialler struct {
+	amqpConn AmqpConn
+}
+
+func (f *fakeDialler) DialConfig(url string, config amqp.Config) (AmqpConn, error) {
+	return f.amqpConn, nil
+}
+
+func Test_NewChannel(t *testing.T) {
+	var testCases = []struct {
+		desc                     string
+		reconnectInterval        time.Duration
+		channelError             error
+		expectedError            error
+		numberOfTimesToReturnErr int
+		retryForever             bool
+		channel                  *amqp.Channel
+	}{
+		{
+			desc:              "for a general case, when amqp returns a channel, return a new usable channel to the caller",
+			reconnectInterval: 1 * time.Second,
+		},
+		{
+			desc:                     "if channel returns an error, more than twice, we don't retry after that",
+			channelError:             errors.New("channel error"),
+			expectedError:            pkgerrors.Wrap(errors.New("channel error"), "error getting channel from amqp"),
+			numberOfTimesToReturnErr: 2,
+		},
+		{
+			desc:                     "if channel returns an error, newchannel tries again to get a success",
+			channelError:             errors.New("channel error"),
+			numberOfTimesToReturnErr: 1,
+		},
+		{
+			desc:                     "if channel returns an error, more than twice and retry forever is chosen, we retry till theres no error",
+			channelError:             errors.New("channel error"),
+			numberOfTimesToReturnErr: 2,
+			retryForever:             true,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.desc, func(t *testing.T) {
+			assert := assert.New(t)
+
+			fakeAmqp := &fakeAmqpConn{
+				ch:                   testCase.channel,
+				err:                  testCase.channelError,
+				noOfCallsToReturnErr: testCase.numberOfTimesToReturnErr,
+			}
+			fd := &fakeDialler{amqpConn: fakeAmqp}
+			conn, err := NewConnection("some-url", testCase.reconnectInterval, nil, fd, "", "")
+			assert.Nil(err)
+
+			if testCase.retryForever {
+				conn = conn.RetryForever()
+			}
+			ch, err := conn.NewChannel()
+
+			assert.IsType(testCase.expectedError, err)
+			if err != nil {
+				assert.Equal(testCase.expectedError.Error(), err.Error())
+			}
+			assert.Equal(testCase.channel, ch)
+			conn.Close()
+
+		})
+	}
 }

--- a/rmq/connection_test.go
+++ b/rmq/connection_test.go
@@ -10,40 +10,6 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-type fakeAmqpConn struct {
-	ch                   *amqp.Channel
-	calls                int
-	noOfCallsToReturnErr int
-	err                  error
-}
-
-func (f *fakeAmqpConn) Channel() (*amqp.Channel, error) {
-	f.calls++
-	if f.calls > f.noOfCallsToReturnErr {
-		return f.ch, nil
-	}
-
-	return f.ch, f.err
-}
-
-func (f *fakeAmqpConn) Close() error {
-	// dont really care about this.
-	return nil
-}
-
-func (f *fakeAmqpConn) NotifyClose(receiver chan *amqp.Error) chan *amqp.Error {
-	// similar we dont use this return value for now.
-	return nil
-}
-
-type fakeDialler struct {
-	amqpConn AmqpConn
-}
-
-func (f *fakeDialler) DialConfig(url string, config amqp.Config) (AmqpConn, error) {
-	return f.amqpConn, nil
-}
-
 func Test_NewChannel(t *testing.T) {
 	var testCases = []struct {
 		desc                     string

--- a/rmq/dialler.go
+++ b/rmq/dialler.go
@@ -1,0 +1,19 @@
+package rmq
+
+import "github.com/streadway/amqp"
+
+// AmqpDialler is a abstraction of a dial function to obtain
+// AmqpConn.
+type AmqpDialler interface {
+	// The amqp.Config is non negotiable here as this interface
+	// has to adhere to streadway/amqp standards and not the
+	// other way around if we want to use their dial.
+	DialConfig(url string, config amqp.Config) (AmqpConn, error)
+}
+
+// DefaultAmqpDialler is just a light wrapper on amqp.DialConfig.
+type DefaultAmqpDialler struct{}
+
+func (d *DefaultAmqpDialler) DialConfig(url string, config amqp.Config) (AmqpConn, error) {
+	return amqp.DialConfig(url, config)
+}

--- a/rmq/dialler.go
+++ b/rmq/dialler.go
@@ -11,9 +11,10 @@ type AmqpDialler interface {
 	DialConfig(url string, config amqp.Config) (AmqpConn, error)
 }
 
-// DefaultAmqpDialler is just a light wrapper on amqp.DialConfig.
+// DefaultAmqpDialler returns an AmqpConn implemented by streadway/amqp.
 type DefaultAmqpDialler struct{}
 
+// DialConfig is just a light wrapper on amqp.DialConfig.
 func (d *DefaultAmqpDialler) DialConfig(url string, config amqp.Config) (AmqpConn, error) {
 	return amqp.DialConfig(url, config)
 }

--- a/rmq/fakes_test.go
+++ b/rmq/fakes_test.go
@@ -1,6 +1,8 @@
 package rmq
 
-import "github.com/streadway/amqp"
+import (
+	"github.com/streadway/amqp"
+)
 
 type fakeAmqpConn struct {
 	ch                   *amqp.Channel

--- a/rmq/fakes_test.go
+++ b/rmq/fakes_test.go
@@ -1,0 +1,43 @@
+package rmq
+
+import "github.com/streadway/amqp"
+
+type fakeAmqpConn struct {
+	ch                   *amqp.Channel
+	calls                int
+	noOfCallsToReturnErr int
+	err                  error
+	channelErrors        []*amqp.Error
+}
+
+func (f *fakeAmqpConn) Channel() (*amqp.Channel, error) {
+	f.calls++
+	if f.calls > f.noOfCallsToReturnErr {
+		return f.ch, nil
+	}
+
+	return f.ch, f.err
+}
+
+func (f *fakeAmqpConn) Close() error {
+	// dont really care about this.
+	return nil
+}
+
+func (f *fakeAmqpConn) NotifyClose(receiver chan *amqp.Error) chan *amqp.Error {
+	// similar we dont use this return value for now.
+	go func() {
+		for _, amqpErr := range f.channelErrors {
+			receiver <- amqpErr
+		}
+	}()
+	return nil
+}
+
+type fakeDialler struct {
+	amqpConn AmqpConn
+}
+
+func (f *fakeDialler) DialConfig(url string, config amqp.Config) (AmqpConn, error) {
+	return f.amqpConn, nil
+}


### PR DESCRIPTION
What this PR does:

- Adds an rmq connection.
- Adds the ability to create a new rmq channel from the connection.
- Makes connection resilient and fault tolerant to errors mid connection and during connection attempts.
- Abstracts out amqp connection in a way that can be mocked out or replaced with a different dialler and connection. 